### PR TITLE
feat: optimize placeholder color in dark mode

### DIFF
--- a/src/views/Config.vue
+++ b/src/views/Config.vue
@@ -129,7 +129,7 @@ onMounted(() => useEventListener(self, 'resize', handleResize))
 
 <style scoped>
 .tipText {
-  color: var(--vt-c-divider-dark-2);
+  color: var(--n-placeholder-color);
   text-align: center;
 }
 </style>

--- a/src/views/Config.vue
+++ b/src/views/Config.vue
@@ -129,7 +129,7 @@ onMounted(() => useEventListener(self, 'resize', handleResize))
 
 <style scoped>
 .tipText {
-  color: var(--n-placeholder-color);
+  color: var(--color-heading);
   text-align: center;
 }
 </style>


### PR DESCRIPTION
<img width="1234" alt="image" src="https://user-images.githubusercontent.com/85140972/227405866-a99c9524-7ee4-4420-87c6-bbf77b58dcdb.png">

暗色模式下中间的 placeholder 我是真看不清，所以来水个 PR。

这是改完之后的：

![image](https://user-images.githubusercontent.com/85140972/227406041-9b4d3274-e06a-4bf9-ba35-c2e793937e7c.png)

![image](https://user-images.githubusercontent.com/85140972/227406111-4ea460b9-705e-43bb-80f4-a71de17ee61a.png)
