### PR TITLE
fix: Array access out of bounds

### DIFF
--- a/src/store/data.ts
+++ b/src/store/data.ts
@@ -89,7 +89,8 @@ const dataStore = defineStore(
     function removeConfigTab(name: string) {
       let index = configList.value.findIndex((item) => item.name === name)
       if (configList.value[index].name === currentConfigName.value) {
-        currentConfigName.value = configList.value[index === 0 ? index + 1 : index + 1].name
+        const currentIndex = index === configList.value.length - 1 ? index - 1 : index + 1
+        currentConfigName.value = configList.value[currentIndex].name
       }
       configList.value.splice(index, 1)
     }


### PR DESCRIPTION
When the length of the tab is greater than 1, the last item cannot be deleted (the last item is selected at this time)