### PR TITLE
fix: 修复预加载配置cdn的url资源拼接错误

### DIFF
--- a/src/hooks/useBaseTsConfig.ts
+++ b/src/hooks/useBaseTsConfig.ts
@@ -7,7 +7,7 @@ import useSettingStore from '@store/setting'
 import { useI18n } from 'vue-i18n'
 
 const loadLink = (libName: string) =>
-  `https://cdn.jsdelivr.net/npm/@tsconfig/${libName}@latest/tsconfig.json`
+  `https://cdn.jsdelivr.net/npm/${libName}@latest/tsconfig.json`
 
 export const renderIcon = (icon: string) => () => h(Icon, { icon })
 const configJsonCache = new Map<string, string>()
@@ -40,7 +40,7 @@ export const configLibIcon: Record<string, string> = {
 export function useBaseTsConfig() {
   /**
    * @link https://github.com/tsconfig/bases
-   * @link loadLink https://cdn.jsdelivr.net/npm/@tsconfig/{liblabel}@latest/tsconfig.json
+   * @link loadLink https://cdn.jsdelivr.net/npm/{liblabel}@latest/tsconfig.json
    */
   const { t } = useI18n()
   const settingStore = useSettingStore()


### PR DESCRIPTION
目前线上预览点击任意预设配置，会因为重复拼接两次`@tsconfig/`而导致资源加载错误。

![image](https://github.com/yue1123/ts-config-helper/assets/26453811/d71ca6ae-256d-4245-a920-313eefe9d414)

