### PR TITLE
fix: buttons cannot fully displayed when the sidebar width is narrow

### DIFF
--- a/src/schema/_tsconfig.json
+++ b/src/schema/_tsconfig.json
@@ -376,11 +376,12 @@
                     "None",
                     "ES2022",
                     "Node16",
-                    "NodeNext"
+                    "NodeNext",
+                    "Preserve"
                   ]
                 },
                 {
-                  "pattern": "^([Cc][Oo][Mm][Mm][Oo][Nn][Jj][Ss]|[AaUu][Mm][Dd]|[Ss][Yy][Ss][Tt][Ee][Mm]|[Ee][Ss]([356]|20(1[567]|2[02])|[Nn][Ee][Xx][Tt])|[Nn][Oo][dD][Ee]16|[Nn][Oo][Dd][Ee][Nn][Ee][Xx][Tt]|[Nn][Oo][Nn][Ee])$"
+                  "pattern": "^([Cc][Oo][Mm][Mm][Oo][Nn][Jj][Ss]|[AaUu][Mm][Dd]|[Ss][Yy][Ss][Tt][Ee][Mm]|[Ee][Ss]([356]|20(1[567]|2[02])|[Nn][Ee][Xx][Tt])|[Nn][Oo][dD][Ee]16|[Nn][Oo][Dd][Ee][Nn][Ee][Xx][Tt]|[Nn][Oo][Nn][Ee]|[Pp][Rr][Ee][Ss][Ee][Rr][Vv][Ee])$"
                 }
               ],
               "markdownDescription": "Specify what module code is generated.\n\nSee more: https://www.typescriptlang.org/tsconfig#module"

--- a/src/views/SidePanel/components/OptionsCheckbox/OptionsCheckbox.vue
+++ b/src/views/SidePanel/components/OptionsCheckbox/OptionsCheckbox.vue
@@ -65,7 +65,7 @@ export default {
           <NCheckbox
             :id="options.flatKeys"
             size="large"
-            class="flex-1 w-full"
+            class="flex-1 w-0"
             :value="options.flatKeys"
           >
             <div


### PR DESCRIPTION
### Description

The buttons cannot fully displayed when the sidebar width is narrow.

![image](https://github.com/yue1123/ts-config-helper/assets/23058788/5bbd2836-091a-4b3f-b011-6492562665f2)

### Linked Issues

#10 